### PR TITLE
Update content to improve positioning of Leaf

### DIFF
--- a/src/components/footer/footer.pug
+++ b/src/components/footer/footer.pug
@@ -5,7 +5,7 @@ mixin footer
         .grid__item
           .footer__cta
             h4.footer__cta-heading
-              | We work closely with our clients to plan, design and build innovative applications.
+              | We work closely with our clients to transform their businesses.
             p.footer__cta-text
               strong Interested in working together?&nbsp;
               | Tell us what you’re looking to achieve, and we’ll start thinking about how we can help.&nbsp;

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -56,22 +56,18 @@
         &:nth-child(1) {
           -ms-grid-row: 1;
           -ms-grid-column: 1;
-          -ms-grid-column-span: 3;
-          grid-column: 1 / 3;
+          grid-column: 1;
         }
 
         &:nth-child(2) {
-          -ms-grid-row: 3;
-          -ms-grid-column: 1;
+          -ms-grid-row: 1;
+          -ms-grid-column: 3;
+          -ms-grid-column-span: 3;
+          grid-column: 2;
         }
 
         &:nth-child(3) {
           -ms-grid-row: 3;
-          -ms-grid-column: 3;
-        }
-
-        &:nth-child(4) {
-          -ms-grid-row: 5;
           -ms-grid-column: 1;
           -ms-grid-column-span: 3;
           grid-column: 1 / 3;

--- a/src/components/form/form.pug
+++ b/src/components/form/form.pug
@@ -23,28 +23,13 @@ mixin form
       legend.form__legend The project
       .form__grid.form__grid--custom
         .form__group
-          span.form__label Is it a brand new product or a re-design of existing product?
-          .form__checkboxes
-            .form__checkbox
-              input#web-app.form__checkbox-input(type="checkbox" name="project_type" value="web-app")
-              label.form__label.form__label--checkbox(for="web-app") Web application
-            .form__checkbox
-              input#mobile-app.form__checkbox-input(type="checkbox" name="project_type" value="mobile-app")
-              label.form__label.form__label--checkbox(for="mobile-app") Mobile app (iOS or Android)
-            .form__checkbox
-              input#website.form__checkbox-input(type="checkbox" name="project_type" value="website")
-              label.form__label.form__label--checkbox(for="website") Website
-            .form__checkbox
-              input#other.form__checkbox-input(type="checkbox" name="project_type" value="other")
-              label.form__label.form__label--checkbox(for="other") Other
-        .form__group
           label.form__label(for="project_estimate") How much are you looking to invest?
           input#project_estimate.form__input(name="project_estimate" type="text" placeholder="£15,000")
         .form__group
           label.form__label(for="project_deadline") Do you have a deadline?
           input#project_deadline.form__input(name="project_deadline" type="text" placeholder="We need it live by May")
         .form__group
-          label.form__label(for="project_description") Tell us about the project
+          label.form__label(for="project_description") How can we help?
           textarea#project_description.form__input.form__input--textarea(name="project_description" rows="7" placeholder="The more you can share with us, the better")
     +button({
       buttonText: "Send your enquiry",

--- a/src/pages/index.pug
+++ b/src/pages/index.pug
@@ -4,7 +4,7 @@ block prepend vars
   -var pageTitle = "Kent based web and mobile development"
   -var metaUrl = "https://weareleaf.com"
   -var metaTitle = "Bespoke software automation"
-  -var metaDescription = "We use research-based insights to build software that automates forward-thinking organisations."
+  -var metaDescription = "We use research and technology to drive automation within forward-thinking organisations."
 
 block pageComponents
   +hero({

--- a/src/pages/index.pug
+++ b/src/pages/index.pug
@@ -3,14 +3,14 @@ extends ../layouts/page.pug
 block prepend vars
   -var pageTitle = "Kent based web and mobile development"
   -var metaUrl = "https://weareleaf.com"
-  -var metaTitle = "Every business is now digital"
-  -var metaDescription = "We blend insights and strategy to create digital products for forward-thinking organisations."
+  -var metaTitle = "Bespoke software automation"
+  -var metaDescription = "We use research-based insights to build software that automates forward-thinking organisations."
 
 block pageComponents
   +hero({
     heroModifier: "home",
-    heroHeading: "Every business is now digital",
-    heroText: "We blend insights and strategy to create digital products for forward-thinking organisations.",
+    heroHeading: metaTitle,
+    heroText: metaDescription,
     heroButton: {
       buttonUrl: "/what-we-do",
       buttonText: "Find out how we do it"
@@ -34,7 +34,7 @@ block pageComponents
               alt: "MyRIFT",
             },
             cardHeading: "Helping the UK to claim tax refunds",
-            cardText: "We helped RIFT re-imagine their MyRIFT web application, allowing UK-based workers to claim tax refunds on the move."
+            cardText: "We helped RIFT re-imagine their web application, making tax refund claims easier to manage for their customers and staff."
           })
 
         .grid__item
@@ -46,5 +46,5 @@ block pageComponents
               alt: "HEHA!",
             },
             cardHeading: "Taking the hassle out of travel",
-            cardText: "Planning trips can be a headache. We worked with Holiday Extras to create HEHA!, an iOS and Android app to make the journey easier."
+            cardText: "Planning trips can be a headache. We worked with Holiday Extras to create HEHA!, an iOS and Android app to make the task simple."
           })

--- a/src/pages/our-work.pug
+++ b/src/pages/our-work.pug
@@ -5,13 +5,13 @@ block prepend vars
   -var pageTitle = "Our Work - Leaf"
   -var metaUrl = "https://weareleaf.com/our-work"
   -var metaTitle = "Our work"
-  -var metaDescription = "We're lucky enough to have helped some wonderful clients in achieving their goals."
+  -var metaDescription = "We've helped some wonderful clients add automation to their products and services."
 
 block pageComponents
   +hero({
     heroModifier: "our-work",
-    heroHeading: "Our work",
-    heroText: "We're lucky enough to have helped some wonderful clients in achieving their goals.",
+    heroHeading: metaTitle,
+    heroText: metaDescription,
     heroImage: {
       src: "/assets/images/our-work.webp",
       fallbackSrc: "/assets/images/our-work.png",
@@ -24,18 +24,6 @@ block pageComponents
       .grid.grid--card
         .grid__item
           +card({
-            cardUrl: "/keen",
-            cardImage: {
-              src: "/assets/images/keen.webp",
-              fallbackSrc: "/assets/images/keen.jpg",
-              alt: "Keen",
-            },
-            cardHeading: "Onboarding users the right way",
-            cardText: "No two users are the same, and shouldn’t be treated as such. We partnered with Keen to build an MVP of their customer-success tool."
-          })
-
-        .grid__item
-          +card({
             cardUrl: "/heha",
             cardImage: {
               src: "/assets/images/heha.webp",
@@ -43,7 +31,7 @@ block pageComponents
               alt: "HEHA!",
             },
             cardHeading: "Taking the hassle out of travel",
-            cardText: "Planning trips can be a headache. We worked with Holiday Extras to create HEHA!, an iOS and Android app to make the journey easier."
+            cardText: "Planning trips can be a headache. We worked with Holiday Extras to create HEHA!, an iOS and Android app to make the task simple."
           })
 
         .grid__item
@@ -55,7 +43,19 @@ block pageComponents
               alt: "MyRIFT",
             },
             cardHeading: "Helping the UK to claim tax refunds",
-            cardText: "We helped RIFT re-imagine their MyRIFT web application, allowing UK-based workers to claim tax refunds on the move."
+            cardText: "We helped RIFT re-imagine their web application, making tax refund claims easier to manage for their customers and staff."
+          })
+
+        .grid__item
+          +card({
+            cardUrl: "/keen",
+            cardImage: {
+              src: "/assets/images/keen.webp",
+              fallbackSrc: "/assets/images/keen.jpg",
+              alt: "Keen",
+            },
+            cardHeading: "Onboarding users the right way",
+            cardText: "No two users are the same, and shouldn’t be treated as such. We partnered with Keen to build an MVP of their customer-success tool."
           })
 
         .grid__item

--- a/src/pages/what-we-do.pug
+++ b/src/pages/what-we-do.pug
@@ -5,12 +5,12 @@ block prepend vars
   -var pageTitle = 'What we do - Leaf'
   -var metaUrl = "https://weareleaf.com/what-we-do"
   -var metaTitle = "What we do"
-  -var metaDescription = "We don’t consider ourselves an agency, and don’t act like one. We’re in it for the long haul."
+  -var metaDescription = "Research ensures our software automates the right problems, experience ensures we deliver effectively."
 
 block pageComponents
   +hero({
-    heroHeading: "What we do",
-    heroText: "We don’t consider ourselves an agency, and don’t act like one. We’re in it for the long haul.",
+    heroHeading: metaTitle,
+    heroText: metaDescription,
     heroImage: {
       src: "/assets/images/what-we-do.webp",
       fallbackSrc: "/assets/images/what-we-do.png",
@@ -21,8 +21,8 @@ block pageComponents
   section.section
     .container
       +block({
-        blockHeading: "Insight",
-        blockContent: "<ul class=\"styled-list styled-list--inside-sm\"><li class=\"styled-list__item\"><strong>Behavioural analytics</strong> allow you to see what users are doing on your digital products, identifying sticking points based on actual user data.</li><li class=\"styled-list__item\"><strong>Split testing</strong> allows us to put multiple variants of a feature head to head to see which is best for your business, driving continual improvement.</li><li class=\"styled-list__item\"><strong>Staff shadowing</strong> gives us insight into any unnecessary overheads in your business processes, identifying opportunities for automation.</li></ul>",
+        blockHeading: "Research",
+        blockContent: "<p>First, we verify the problems you're having. We use techniques like <strong>staff shadowing</strong>, <strong>behavioural analytics</strong>, and <strong>recorded user sessions</strong> to validate any assumptions and establish a baseline for efficiency in the processes you're looking to improve.</p><p>From this, we'll put together a series of <strong>recommendations</strong> for using software to improve your level of automation, along with rationale on the benefits to your staff, customers, and bottom line.</p>",
         blockImage: {
           src: "/assets/images/insight.webp",
           fallbackSrc: "/assets/images/insight.jpg",
@@ -32,7 +32,7 @@ block pageComponents
 
       +block({
         blockHeading: "Design",
-        blockContent: "<ul class=\"styled-list styled-list--inside-sm\"><li class=\"styled-list__item\"><strong>Sketching and wireframing</strong> places a focus on the underlying design problems that need solving, rather than shallow visual details of your product.</li><li class=\"styled-list__item\"><strong>Prototyping</strong> provides a cost-effective method of overcoming technological and design hurdles before building a product or feature.</li><li class=\"styled-list__item\"><strong>Visual design</strong> gives a polished and professional validation to your product, whilst helping build trust and familiarity with your brand itself.</li><li class=\"styled-list__item\"><strong>Styleguides</strong> and <strong>Pattern libraries</strong> promote a consistent design language, informing future design decisions for more efficient development process.</li></ul>",
+        blockContent: "<p>Next, we work through each of our recommendations, designing automated solutions to bottlenecks in your business processes. We use <strong>sketching</strong>, <strong>wireframing</strong>, <strong>prototyping</strong>, and <strong>visual design</strong> to communicate a clear vision for how your software will work.</p><p>This allows us to identify and eliminate technological and design hurdles early on, while promoting confidence in the end result from stakeholders, staff, and customers.</p>",
         blockImage: {
           src: "/assets/images/design.webp",
           fallbackSrc: "/assets/images/design.jpg",
@@ -43,7 +43,7 @@ block pageComponents
 
       +block({
         blockHeading: "Development",
-        blockContent: "<ul class=\"styled-list styled-list--inside-sm\"><li class=\"styled-list__item\"><strong>Software engineering</strong> with cutting edge JavaScript, Node and Ruby means we’re able to deliver value quickly on a wide range of products.</li><li class=\"styled-list__item\"><strong>Technical leadership</strong> is in our DNA. We promote best practices, ownership, and trust in order to get the best from development teams.</li><li class=\"styled-list__item\"><strong>Business automation</strong> removes bottlenecks in your daily operations with software. This promotes speed, quality, and scalability in your business.</li><li class=\"styled-list__item\"><strong>Automated testing</strong> checks that your products are working properly, meaning we can confidently make website or app changes at a moments notice.</li><li class=\"styled-list__item\"><strong>Peer reviewed code</strong> ensures that only well implemented work make it through to your customers, keeping quality high and bug counts low.</li></ul>",
+        blockContent: "<p>Finally, we use technologies like <strong>React</strong>, <strong>Node.js</strong> and <strong>Ruby</strong> to build and deliver the designed solutions. To verify success, we measure the updated processes against our original baseline from the research phase.</p><p>Everything we build is backed by extensive <strong>automated testing</strong>, stringent <strong>code review</strong> processes, and live <strong>performance monitoring</strong> to ensure continual bug-free operation.</p>",
         blockImage: {
           src: "/assets/images/development.webp",
           fallbackSrc: "/assets/images/development.jpg",

--- a/src/pages/what-we-do.pug
+++ b/src/pages/what-we-do.pug
@@ -22,7 +22,7 @@ block pageComponents
     .container
       +block({
         blockHeading: "Research",
-        blockContent: "<p>First, we verify the problems you're having. We use techniques like <strong>staff shadowing</strong>, <strong>behavioural analytics</strong>, and <strong>recorded user sessions</strong> to validate any assumptions and establish a baseline for efficiency in the processes you're looking to improve.</p><p>From this, we'll put together a series of <strong>recommendations</strong> for using software to improve your level of automation, along with rationale on the benefits to your staff, customers, and bottom line.</p>",
+        blockContent: "<p>We use techniques like <strong>staff shadowing</strong> and <strong>behavioural analytics</strong> to help uncover automation opportunities, and recorded user sessions to validate any assumptions and establish an efficiency baseline in the existing processes.</p><p>We'll make a series of recommendations on how software could automate both internal processes and external data-capture, along with rationale on the benefits to your staff, customers, and bottom line.</p>",
         blockImage: {
           src: "/assets/images/insight.webp",
           fallbackSrc: "/assets/images/insight.jpg",
@@ -32,7 +32,7 @@ block pageComponents
 
       +block({
         blockHeading: "Design",
-        blockContent: "<p>Next, we work through each of our recommendations, designing automated solutions to bottlenecks in your business processes. We use <strong>sketching</strong>, <strong>wireframing</strong>, <strong>prototyping</strong>, and <strong>visual design</strong> to communicate a clear vision for how your software will work.</p><p>This allows us to identify and eliminate technological and design hurdles early on, while promoting confidence in the end result from stakeholders, staff, and customers.</p>",
+        blockContent: "<p>We design automated solutions to bottlenecks in your business processes, using <strong>sketching</strong>, <strong>wireframing</strong>, <strong>prototyping</strong>, and <strong>visual design</strong> to communicate a clear vision for how your software will work.</p><p>Introducing design-thinking early in the process allows us to identify and eliminate technological and design hurdles early on, while promoting confidence in the end result from stakeholders, staff, and customers.</p>",
         blockImage: {
           src: "/assets/images/design.webp",
           fallbackSrc: "/assets/images/design.jpg",
@@ -43,7 +43,7 @@ block pageComponents
 
       +block({
         blockHeading: "Development",
-        blockContent: "<p>Finally, we use technologies like <strong>React</strong>, <strong>Node.js</strong> and <strong>Ruby</strong> to build and deliver the designed solutions. To verify success, we measure the updated processes against our original baseline from the research phase.</p><p>Everything we build is backed by extensive <strong>automated testing</strong>, stringent <strong>code review</strong> processes, and live <strong>performance monitoring</strong> to ensure continual bug-free operation.</p>",
+        blockContent: "<p>We use technologies like <strong>React</strong>, <strong>Node.js</strong> and <strong>Ruby</strong> to build and deliver the designed solutions. To verify success, we measure our results with state of the art analytics.</p><p>Everything we build is backed by extensive <strong>automated testing</strong>, stringent <strong>code review</strong> processes, and live <strong>performance monitoring</strong> to ensure continual bug-free operation.</p>",
         blockImage: {
           src: "/assets/images/development.webp",
           fallbackSrc: "/assets/images/development.jpg",


### PR DESCRIPTION
This updates the content of the website to re-position us as a company that focusses on software automation in businesses.

I've updated a few sets of content across a few pages, but here's the bulk of it:

**Landing page**
Here I've updated the heading, intro text and project intros:
![screencapture-localhost-3000-2019-05-14-12_47_33](https://user-images.githubusercontent.com/1911741/57695647-b7813f80-7646-11e9-9556-c1fbc365a352.png)

**What we do page**
Everything on this page has been updated:
![screencapture-localhost-3000-what-we-do-2019-05-14-12_47_51](https://user-images.githubusercontent.com/1911741/57695654-bd772080-7646-11e9-85ee-c0677d0a8b01.png)

**Project planner page**
I removed the question asking whether the lead is looking to build a website, mobile app, etc as it seemed kind of irrelevant in the context of the new positioning.
![screencapture-localhost-3000-project-planner-2019-05-14-12_48_15](https://user-images.githubusercontent.com/1911741/57695669-c36d0180-7646-11e9-960e-74e0db6ff50c.png)

