### PR TITLE
Fix contact modal on mobile devices by vertically centering.

### DIFF
--- a/src/components/contact/_contact.scss
+++ b/src/components/contact/_contact.scss
@@ -4,7 +4,11 @@
     display: grid;
     grid-template-columns: 1fr;
     grid-gap: $spacing-8;
-    padding: $spacing-8;
+    padding: $spacing-4 $spacing-8;
+
+    @media screen and (min-width: map-get($breakpoints, 'breakpoint-1')) {
+      padding: $spacing-8;
+    }
 
     @media screen and (min-width: map-get($breakpoints, 'breakpoint-3')) {
       grid-template-columns: 1fr 1fr;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -32,7 +32,11 @@
   }
 
   &__container {
+    align-items: flex-end;
     background-color: $color-container;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     height: 100vh;
     max-height: 100vh;
     position: relative;
@@ -41,6 +45,7 @@
     will-change: transform;
 
     @media screen and (min-width: map-get($breakpoints, 'breakpoint-1')) {
+      display: block;
       border-radius: 1rem;
       height: auto;
       max-width: 44rem;
@@ -63,13 +68,18 @@
     font-size: $font-size-h2;
     line-height: 1;
     outline: none;
+    margin-right: 1.25rem;
     padding: 0;
-    position: absolute;
-    right: $spacing-6;
-    top: $spacing-6;
 
     &::before {
       content: url('/assets/images/icons/close.svg');
+    }
+
+    @media screen and (min-width: map-get($breakpoints, 'breakpoint-1')) {
+      margin-right: 0;
+      position: absolute;
+      right: $spacing-6;
+      top: $spacing-6;
     }
 
     @media screen and (min-width: map-get($breakpoints, 'breakpoint-6')) {


### PR DESCRIPTION
Fixes the contact modal on phones, by vertically centering it using flexbox. Previously, the close button was getting lost at the top of the screen under the phone UI. Larger screen displays 

<img width="559" alt="Screenshot 2020-01-25 at 12 55 45" src="https://user-images.githubusercontent.com/1911741/73121436-0fac6780-3f72-11ea-85ba-2e20981d832d.png">
